### PR TITLE
feat: add PoE port power reporting to wired clients, APs and switches

### DIFF
--- a/app.js
+++ b/app.js
@@ -52,8 +52,10 @@ class UnifiNetwork extends Homey.App {
 
     /**
      * parseWebsocketMessage
+     * @param {object} payload - the data entry from the WebSocket message
+     * @param {object} [meta]  - the meta object from the WebSocket message (contains message type)
      */
-    parseWebsocketMessage(payload) {
+    parseWebsocketMessage(payload, meta) {
         let that = this;
         // start application flow cards
         // created a setting because this function has memory overload on Homey
@@ -120,6 +122,44 @@ class UnifiNetwork extends Homey.App {
                     device.onBlockedChange(tokens);
                 }
             }
+        }
+
+        // device:sync is independent of subsystem — check separately so it is never
+        // accidentally swallowed by the wlan/lan branches above
+        if (meta && meta.message === 'device:sync' && payload.mac) {
+            // Real-time switch status update — debug only to avoid log flooding (~30s cadence per switch)
+            that.homey.app.debug(`[websocket] [device:sync]: mac=${payload.mac}`);
+
+            // Update port up/down and PoE on/off state on the switch device itself
+            const switchDriver = that.homey.drivers.getDriver('network-switch');
+            const switchDevice = switchDriver.getUnifiDeviceById(payload.mac);
+            if (switchDevice) {
+                switchDevice.onStatusChange(payload);
+            }
+
+            // Push live PoE wattage to any device powered by a port on this switch.
+            // Covers cable-clients, access-points, and PoE-powered downstream switches —
+            // all use PoePowerMixin and store _swMac/_swPort for exactly this lookup.
+            if (payload.port_table) {
+                for (const driverName of ['cable-client', 'access-point', 'network-switch']) {
+                    let driver;
+                    try {
+                        driver = that.homey.drivers.getDriver(driverName);
+                    } catch (e) { /* driver not yet initialised — skip */ continue; }
+                    driver.getDevices().forEach(async device => {
+                        if (device._swMac === payload.mac && device._swPort) {
+                            const port = payload.port_table[device._swPort - 1];
+                            if (port && port.port_poe && typeof port.poe_power !== 'undefined') {
+                                if (typeof device._ensurePoeCapabilities === 'function') {
+                                    await device._ensurePoeCapabilities(port);
+                                }
+                                device.onPoeUpdate(port);
+                            }
+                        }
+                    });
+                }
+            }
+
         }
         that = null;
     }
@@ -415,7 +455,7 @@ class UnifiNetwork extends Homey.App {
     }
 
     async refreshAuthTokens() {
-        const refreshAuthTokens = setInterval(() => {
+        const refreshAuthTokens = this.homey.setInterval(() => {
             try {
                 this.debug('Refreshing auth tokens');
                 this._appLogin();

--- a/app.json
+++ b/app.json
@@ -1601,6 +1601,177 @@
     {
       "id": "access-point",
       "name": {
+        "en": "Access Point",
+        "nl": "Toegangspunt",
+        "es": "Punto de acceso",
+        "de": "Zugangspunkt",
+        "fr": "Point d'accès",
+        "it": "Punto di accesso",
+        "da": "Adgangspunkt",
+        "sv": "Åtkomstpunkt",
+        "no": "Tilgangspunkt",
+        "ko": "액세스 포인트",
+        "ru": "Точка доступа",
+        "pt": "Ponto de acesso"
+      },
+      "images": {
+        "xlarge": "drivers/access-point/assets/images/xlarge.png",
+        "large": "drivers/access-point/assets/images/large.png",
+        "small": "drivers/access-point/assets/images/small.png"
+      },
+      "class": "sensor",
+      "capabilities": [],
+      "capabilitiesOptions": {},
+      "pair": [
+        {
+          "id": "list_clients",
+          "template": "list_devices",
+          "navigation": {
+            "next": "add_clients"
+          }
+        },
+        {
+          "id": "add_clients",
+          "template": "add_devices"
+        }
+      ]
+    },
+    {
+      "id": "cable-client",
+      "name": {
+        "en": "Wired client",
+        "nl": "Bedrade cliënt",
+        "es": "Cliente cableado",
+        "de": "Verkabelter Client",
+        "fr": "Client câblé",
+        "it": "Client cablato",
+        "da": "Kablet klient",
+        "sv": "Kabelansluten klient",
+        "no": "Kablet klient",
+        "ko": "유선 클라이언트",
+        "ru": "Проводной клиент",
+        "pt": "Cliente com fio"
+      },
+      "mobile": {
+        "components": [
+          {
+            "id": "icon"
+          },
+          {
+            "id": "sensor",
+            "capabilities": [
+              "onoff",
+              "connected",
+              "blocked"
+            ],
+            "capabilitiesOptions": {
+              "onoff": {
+                "title": {
+                  "en": "Connection state",
+                  "nl": "Verbindingsstatus",
+                  "es": "Estado de Verbindings",
+                  "de": "Verbindungsstatus",
+                  "fr": "État de la connexion",
+                  "it": "Stato della connessione",
+                  "da": "Forbindelsesstatus",
+                  "sv": "Anslutningsstatus",
+                  "no": "Tilkoblingsstatus",
+                  "ko": "연결 상태",
+                  "ru": "Состояние подключения",
+                  "pt": "Estado da conexão"
+                }
+              },
+              "getable": true,
+              "setable": false
+            },
+            "options": {
+              "icons": {
+                "connected": "assets/connected.svg"
+              },
+              "connected": {
+                "noblink": false,
+                "invert": true,
+                "label": {
+                  "true": {
+                    "en": "Connected",
+                    "es": "Conectado",
+                    "de": "Verbunden",
+                    "fr": "Connecté",
+                    "it": "Connesso",
+                    "da": "Tilsluttet",
+                    "sv": "Ansluten",
+                    "no": "Tilkoblet",
+                    "ko": "연결됨",
+                    "ru": "Подключено",
+                    "pt": "Conectado"
+                  },
+                  "false": {
+                    "en": "Disconnected",
+                    "es": "Desconectado",
+                    "de": "Getrennt",
+                    "fr": "Déconnecté",
+                    "it": "Disconnesso",
+                    "da": "Frakoblet",
+                    "sv": "Frånkopplad",
+                    "no": "Frakoblet",
+                    "ko": "연결 끊김",
+                    "ru": "Отключено",
+                    "pt": "Desconectado"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "images": {
+        "xlarge": "drivers/cable-client/assets/images/xlarge.png",
+        "large": "drivers/cable-client/assets/images/large.png",
+        "small": "drivers/cable-client/assets/images/small.png"
+      },
+      "class": "sensor",
+      "capabilities": [
+        "onoff",
+        "connected",
+        "blocked"
+      ],
+      "capabilitiesOptions": {
+        "onoff": {
+          "title": {
+            "en": "Connection state",
+            "nl": "Verbindingsstatus",
+            "es": "Estado de Verbindings",
+            "de": "Verbindungsstatus",
+            "fr": "État de la connexion",
+            "it": "Stato della connessione",
+            "da": "Forbindelsesstatus",
+            "sv": "Anslutningsstatus",
+            "no": "Tilkoblingsstatus",
+            "ko": "연결 상태",
+            "ru": "Состояние подключения",
+            "pt": "Estado da conexão"
+          },
+          "getable": true,
+          "setable": false
+        }
+      },
+      "pair": [
+        {
+          "id": "list_clients",
+          "template": "list_devices",
+          "navigation": {
+            "next": "add_clients"
+          }
+        },
+        {
+          "id": "add_clients",
+          "template": "add_devices"
+        }
+      ]
+    },
+    {
+      "id": "network-switch",
+      "name": {
         "en": "Network Switch",
         "nl": "Netwerk Switch",
         "es": "Interruptor de red",
@@ -3250,177 +3421,6 @@
           }
         }
       },
-      "pair": [
-        {
-          "id": "list_clients",
-          "template": "list_devices",
-          "navigation": {
-            "next": "add_clients"
-          }
-        },
-        {
-          "id": "add_clients",
-          "template": "add_devices"
-        }
-      ]
-    },
-    {
-      "id": "cable-client",
-      "name": {
-        "en": "Wired client",
-        "nl": "Bedrade cliënt",
-        "es": "Cliente cableado",
-        "de": "Verkabelter Client",
-        "fr": "Client câblé",
-        "it": "Client cablato",
-        "da": "Kablet klient",
-        "sv": "Kabelansluten klient",
-        "no": "Kablet klient",
-        "ko": "유선 클라이언트",
-        "ru": "Проводной клиент",
-        "pt": "Cliente com fio"
-      },
-      "mobile": {
-        "components": [
-          {
-            "id": "icon"
-          },
-          {
-            "id": "sensor",
-            "capabilities": [
-              "onoff",
-              "connected",
-              "blocked"
-            ],
-            "capabilitiesOptions": {
-              "onoff": {
-                "title": {
-                  "en": "Connection state",
-                  "nl": "Verbindingsstatus",
-                  "es": "Estado de Verbindings",
-                  "de": "Verbindungsstatus",
-                  "fr": "État de la connexion",
-                  "it": "Stato della connessione",
-                  "da": "Forbindelsesstatus",
-                  "sv": "Anslutningsstatus",
-                  "no": "Tilkoblingsstatus",
-                  "ko": "연결 상태",
-                  "ru": "Состояние подключения",
-                  "pt": "Estado da conexão"
-                }
-              },
-              "getable": true,
-              "setable": false
-            },
-            "options": {
-              "icons": {
-                "connected": "assets/connected.svg"
-              },
-              "connected": {
-                "noblink": false,
-                "invert": true,
-                "label": {
-                  "true": {
-                    "en": "Connected",
-                    "es": "Conectado",
-                    "de": "Verbunden",
-                    "fr": "Connecté",
-                    "it": "Connesso",
-                    "da": "Tilsluttet",
-                    "sv": "Ansluten",
-                    "no": "Tilkoblet",
-                    "ko": "연결됨",
-                    "ru": "Подключено",
-                    "pt": "Conectado"
-                  },
-                  "false": {
-                    "en": "Disconnected",
-                    "es": "Desconectado",
-                    "de": "Getrennt",
-                    "fr": "Déconnecté",
-                    "it": "Disconnesso",
-                    "da": "Frakoblet",
-                    "sv": "Frånkopplad",
-                    "no": "Frakoblet",
-                    "ko": "연결 끊김",
-                    "ru": "Отключено",
-                    "pt": "Desconectado"
-                  }
-                }
-              }
-            }
-          }
-        ]
-      },
-      "images": {
-        "xlarge": "drivers/cable-client/assets/images/xlarge.png",
-        "large": "drivers/cable-client/assets/images/large.png",
-        "small": "drivers/cable-client/assets/images/small.png"
-      },
-      "class": "sensor",
-      "capabilities": [
-        "onoff",
-        "connected",
-        "blocked"
-      ],
-      "capabilitiesOptions": {
-        "onoff": {
-          "title": {
-            "en": "Connection state",
-            "nl": "Verbindingsstatus",
-            "es": "Estado de Verbindings",
-            "de": "Verbindungsstatus",
-            "fr": "État de la connexion",
-            "it": "Stato della connessione",
-            "da": "Forbindelsesstatus",
-            "sv": "Anslutningsstatus",
-            "no": "Tilkoblingsstatus",
-            "ko": "연결 상태",
-            "ru": "Состояние подключения",
-            "pt": "Estado da conexão"
-          },
-          "getable": true,
-          "setable": false
-        }
-      },
-      "pair": [
-        {
-          "id": "list_clients",
-          "template": "list_devices",
-          "navigation": {
-            "next": "add_clients"
-          }
-        },
-        {
-          "id": "add_clients",
-          "template": "add_devices"
-        }
-      ]
-    },
-    {
-      "id": "network-switch",
-      "name": {
-        "en": "Access Point",
-        "nl": "Toegangspunt",
-        "es": "Punto de acceso",
-        "de": "Zugangspunkt",
-        "fr": "Point d'accès",
-        "it": "Punto di accesso",
-        "da": "Adgangspunkt",
-        "sv": "Åtkomstpunkt",
-        "no": "Tilgangspunkt",
-        "ko": "액세스 포인트",
-        "ru": "Точка доступа",
-        "pt": "Ponto de acesso"
-      },
-      "images": {
-        "xlarge": "drivers/access-point/assets/images/xlarge.png",
-        "large": "drivers/access-point/assets/images/large.png",
-        "small": "drivers/access-point/assets/images/small.png"
-      },
-      "class": "sensor",
-      "capabilities": [],
-      "capabilitiesOptions": {},
       "pair": [
         {
           "id": "list_clients",

--- a/drivers/access-point/device.js
+++ b/drivers/access-point/device.js
@@ -1,13 +1,15 @@
 'use strict';
 
 const {Device} = require('homey');
+const PoePowerMixin = require('../../library/poe-power-mixin');
 
-class AccessPointDevice extends Device {
+class AccessPointDevice extends PoePowerMixin(Device) {
 
     /**
      * onInit is called when the device is initialized.
      */
     async onInit() {
+        await this.initPoeMeter(); // restore kWh total from store (from PoePowerMixin)
         await this.waitForBootstrap();
         this.log('Access-Point has been initialized');
     }
@@ -53,6 +55,7 @@ class AccessPointDevice extends Device {
      * onDeleted is called when the user deleted the device.
      */
     async onDeleted() {
+        this.destroyPoeMeter();
         this.log('Access-Point has been deleted');
     }
 
@@ -71,6 +74,14 @@ class AccessPointDevice extends Device {
                 device = device.filter(obj => obj.mac === this.getData().id);
                 this.homey.log(JSON.stringify(device));
 
+                if (device[0]) {
+                    // Store uplink switch info and seed initial PoE readings (from PoePowerMixin)
+                    // APs use uplink.uplink_mac / uplink.uplink_remote_port
+                    this.updatePoeUplink(device[0]);
+                    if (this._swMac && this._swPort) {
+                        this._fetchPoeData(this._swMac, this._swPort);
+                    }
+                }
             }).catch(error => this.homey.app.debug(error));
         }
     }
@@ -80,6 +91,8 @@ class AccessPointDevice extends Device {
             this.onIPChange(playloadMessage);
         }
 
+        // Keep uplink info up to date for real-time device:sync power pushes
+        this.updatePoeUplink(playloadMessage);
     }
 }
 

--- a/drivers/cable-client/device.js
+++ b/drivers/cable-client/device.js
@@ -1,13 +1,15 @@
 'use strict';
 
 const {Device} = require('homey');
+const PoePowerMixin = require('../../library/poe-power-mixin');
 
-class CableDevice extends Device {
+class CableDevice extends PoePowerMixin(Device) {
 
     /**
      * onInit is called when the device is initialized.
      */
     async onInit() {
+        await this.initPoeMeter(); // restore kWh total from store (from PoePowerMixin)
         await this._createMissingCapabilities();
         this.getDeviceStatus();
 
@@ -55,6 +57,7 @@ class CableDevice extends Device {
      * onDeleted is called when the user deleted the device.
      */
     async onDeleted() {
+        this.destroyPoeMeter();
         this.log('CableDevice has been deleted');
     }
 
@@ -132,9 +135,17 @@ class CableDevice extends Device {
                 if (typeof device[0].blocked !== 'undefined') {
                     this.onBlockedChange(device[0]);
                 }
+
+                // Normalise uplink fields and seed initial PoE readings (from PoePowerMixin)
+                this.updatePoeUplink(device[0]);
+                if (this._swMac && this._swPort) {
+                    this._fetchPoeData(this._swMac, this._swPort);
+                }
             }).catch(error => this.homey.app.debug(error));
         }
     }
+
+    // _fetchPoeData, _ensurePoeCapabilities, onPoeUpdate all live in PoePowerMixin
 
     onBlockedChange(data) {
         if (this.hasCapability('blocked')) {
@@ -150,6 +161,9 @@ class CableDevice extends Device {
         if (typeof playloadMessage.blocked !== 'undefined') {
             this.onBlockedChange(playloadMessage);
         }
+
+        // Keep uplink info up to date — used by device:sync handler for real-time power pushes
+        this.updatePoeUplink(playloadMessage);
     }
 }
 

--- a/drivers/network-switch/device.js
+++ b/drivers/network-switch/device.js
@@ -1,13 +1,15 @@
 'use strict';
 
 const {Device} = require('homey');
+const PoePowerMixin = require('../../library/poe-power-mixin');
 
-class NetworkSwitchDevice extends Device {
+class NetworkSwitchDevice extends PoePowerMixin(Device) {
 
     /**
      * onInit is called when the device is initialized.
      */
     async onInit() {
+        await this.initPoeMeter(); // restore kWh total from store (from PoePowerMixin)
         await this.waitForBootstrap();
 
         this.registerCapabilityListener("poe", async (value) => {
@@ -62,7 +64,8 @@ class NetworkSwitchDevice extends Device {
      * onDeleted is called when the user deleted the device.
      */
     async onDeleted() {
-        this.log('CableDevice has been deleted');
+        this.destroyPoeMeter();
+        this.log('Network-Switch has been deleted');
     }
 
     async _createMissingCapabilities() {
@@ -176,20 +179,30 @@ class NetworkSwitchDevice extends Device {
     getDeviceStatus() {
         if (this.homey.app.loggedIn === true) {
             this.homey.app.api.unifi.getAccessDevices(this.getData().id).then(device => {
-                if (typeof device[0].ip !== 'undefined') {
-                    this.onIPChange(device[0]);
+                // Filter by MAC so we always use this switch's own data, not another device at index 0
+                const networkSwitch = device.filter(obj => obj.mac === this.getData().id);
+                if (!networkSwitch[0]) return;
+
+                if (typeof networkSwitch[0].ip !== 'undefined') {
+                    this.onIPChange(networkSwitch[0]);
                 }
 
-                if (typeof device[0].port_table !== 'undefined') {
-                    this.onAmountPortsChange(device[0].port_table.length);
-                    for (let i = 1; i < device[0].port_table.length + 1; i++) {
-                        if (typeof device[0].port_table[i - 1].up !== 'undefined') {
-                            this.onUPChange(device[0].port_table[i - 1].up, i);
+                if (typeof networkSwitch[0].port_table !== 'undefined') {
+                    this.onAmountPortsChange(networkSwitch[0].port_table.length);
+                    for (let i = 1; i < networkSwitch[0].port_table.length + 1; i++) {
+                        if (typeof networkSwitch[0].port_table[i - 1].up !== 'undefined') {
+                            this.onUPChange(networkSwitch[0].port_table[i - 1].up, i);
                         }
-                        if (typeof device[0].port_table[i - 1].poe_enable !== 'undefined') {
-                            this.onPOEChange(device[0].port_table[i - 1].poe_enable, i);
+                        if (typeof networkSwitch[0].port_table[i - 1].poe_enable !== 'undefined') {
+                            this.onPOEChange(networkSwitch[0].port_table[i - 1].poe_enable, i);
                         }
                     }
+                }
+
+                // If this switch is itself PoE-powered by an upstream switch, track its own draw
+                this.updatePoeUplink(networkSwitch[0]);
+                if (this._swMac && this._swPort) {
+                    this._fetchPoeData(this._swMac, this._swPort);
                 }
 
             }).catch(error => this.homey.app.debug(error));

--- a/library/apiclient.js
+++ b/library/apiclient.js
@@ -22,6 +22,10 @@ class ApiClient extends BaseClass {
     }
 
     setWebSocketObject(hostName, portNumber, userName, passWord, siteName) {
+        // Cleanly shut down old client (stops reconnect loop + terminates socket)
+        if (this.websocket) {
+            this.websocket.destroy();
+        }
         const options = {host: hostName, port: portNumber, sslverify: false, site: siteName};
         this.websocket = new WebsocketClient(options, this.homey);
     }

--- a/library/poe-power-mixin.js
+++ b/library/poe-power-mixin.js
@@ -1,0 +1,133 @@
+'use strict';
+
+/**
+ * PoePowerMixin — adds PoE power reporting to any Homey device that is itself
+ * powered via a PoE switch port (cable-clients, access points, PoE-powered switches).
+ *
+ * Usage:
+ *   const PoePowerMixin = require('../../library/poe-power-mixin');
+ *   class MyDevice extends PoePowerMixin(Device) { ... }
+ *
+ * Each device must call:
+ *   await this.initPoeMeter()   — in onInit, before getDeviceStatus()
+ *   this.updatePoeUplink(data)  — whenever a UniFi payload arrives, so the
+ *                                 device:sync handler can push real-time updates
+ *
+ * UniFi uses two different field layouts depending on device type:
+ *   Client devices      → { sw_mac, sw_port }
+ *   Infrastructure devs → { uplink: { uplink_mac, uplink_remote_port } }
+ * updatePoeUplink() normalises both into this._swMac / this._swPort.
+ */
+const PoePowerMixin = (Base) => class extends Base {
+
+    // Call from onInit to restore the accumulated kWh total from persistent storage.
+    // Data survives app restarts and Homey reboots; lost only if the device is deleted + re-paired.
+    // Also starts a 5-minute polling fallback — UniFi device:sync events only carry PoE data when
+    // something changes on the switch, which can be infrequent on stable devices.
+    async initPoeMeter() {
+        this._meterPower = await this.getStoreValue('meter_power') || 0;
+        this._lastPowerTs = null; // null = first reading this session; gap while app was down is skipped
+        this._poePollingInterval = this.homey.setInterval(() => {
+            if (this._swMac && this._swPort) {
+                this._fetchPoeData(this._swMac, this._swPort);
+            }
+        }, 5 * 60 * 1000); // 5 minutes
+    }
+
+    // Call from onDeleted to stop the polling interval.
+    destroyPoeMeter() {
+        if (this._poePollingInterval) {
+            this.homey.clearInterval(this._poePollingInterval);
+            this._poePollingInterval = null;
+        }
+    }
+
+    // Extract the upstream switch MAC + port from whichever field layout UniFi uses,
+    // and store on the instance so the device:sync handler can look us up.
+    updatePoeUplink(payload) {
+        if (payload.sw_mac && payload.sw_port) {
+            // Client devices (cable-client)
+            this._swMac = payload.sw_mac;
+            this._swPort = payload.sw_port;
+        } else if (payload.uplink && payload.uplink.uplink_mac && payload.uplink.uplink_remote_port) {
+            // Infrastructure devices (access-point, network-switch).
+            // _fetchPoeData will confirm whether the port actually delivers PoE; if not,
+            // it removes any stale capabilities left over from previous runs.
+            this._swMac = payload.uplink.uplink_mac;
+            this._swPort = payload.uplink.uplink_remote_port;
+        }
+    }
+
+    // One-time API lookup on boot to seed the initial PoE readings.
+    // Also cleans up stale PoE capabilities on devices that are not actually PoE-powered
+    // (e.g. a mains-powered switch whose upstream port has port_poe: false).
+    async _fetchPoeData(swMac, swPort) {
+        try {
+            const devices = await this.homey.app.api.unifi.getAccessDevices(swMac);
+            const sw = devices.find(d => d.mac === swMac);
+            if (!sw || !sw.port_table) return;
+            const port = sw.port_table[swPort - 1];
+            if (!port || !port.port_poe) {
+                // Upstream port is not a PoE port — this device is not PoE-powered.
+                // Remove any stale PoE capabilities left over from a previous buggy run.
+                await this._removePoeCapabilities();
+                // Clear uplink tracking so polling stops trying
+                this._swMac = null;
+                this._swPort = null;
+                return;
+            }
+            if (typeof port.poe_power === 'undefined') return; // No reading yet; polling will retry
+            await this._ensurePoeCapabilities();
+            this.onPoeUpdate(port);
+        } catch (error) {
+            this.homey.app.debug(error);
+        }
+    }
+
+    // Add the four PoE capabilities sequentially.
+    // Homey SDK can error if you fire multiple addCapability calls in parallel.
+    // Throws on failure so _fetchPoeData can catch it cleanly rather than silently
+    // leaving capabilities half-added and setCapabilityValue calls failing.
+    async _ensurePoeCapabilities() {
+        for (const cap of ['measure_power', 'measure_voltage', 'measure_current', 'meter_power']) {
+            if (!this.hasCapability(cap)) {
+                await this.addCapability(cap);
+            }
+        }
+    }
+
+    // Remove PoE capabilities that were incorrectly added (e.g. when a previous bug caused
+    // a mains-powered device to be treated as PoE-powered).
+    async _removePoeCapabilities() {
+        for (const cap of ['measure_power', 'measure_voltage', 'measure_current', 'meter_power']) {
+            if (this.hasCapability(cap)) {
+                this.log(`removing stale PoE capability '${cap}' from ${this.getName()}`);
+                await this.removeCapability(cap).catch(this.error);
+            }
+        }
+    }
+
+    // Update all four PoE capability values from a UniFi port_table entry.
+    // Called from _fetchPoeData (boot) and the device:sync handler in app.js (real-time).
+    onPoeUpdate(port) {
+        const watts = parseFloat(port.poe_power  || '0');
+        const volts = parseFloat(port.poe_voltage || '0');
+        const amps  = parseFloat(port.poe_current || '0') / 1000; // UniFi reports mA; Homey wants A
+
+        // Accumulate kWh — skip the gap while the app was not running (_lastPowerTs === null)
+        const now = Date.now();
+        if (this._lastPowerTs !== null) {
+            const hoursElapsed = (now - this._lastPowerTs) / 3600000;
+            this._meterPower += (watts / 1000) * hoursElapsed;
+            this.setStoreValue('meter_power', this._meterPower).catch(this.error);
+        }
+        this._lastPowerTs = now;
+
+        if (this.hasCapability('measure_power'))  this.setCapabilityValue('measure_power',  watts).catch(this.error);
+        if (this.hasCapability('measure_voltage')) this.setCapabilityValue('measure_voltage', volts).catch(this.error);
+        if (this.hasCapability('measure_current')) this.setCapabilityValue('measure_current', amps).catch(this.error);
+        if (this.hasCapability('meter_power'))     this.setCapabilityValue('meter_power',     this._meterPower).catch(this.error);
+    }
+};
+
+module.exports = PoePowerMixin;

--- a/library/websocket.js
+++ b/library/websocket.js
@@ -18,6 +18,10 @@ class WebsocketClient extends BaseClass {
 
         this.homey = homey;
         this.lastWebsocketMessage = null;
+        this._isReconnecting = false; // must be initialized; undefined !== false breaks the reconnect guard
+        this._lastPong = null;
+        this._closed = false; // set to true when this client is intentionally replaced, to stop reconnect loops
+        this._pingpong = null; // stored on instance so it can be cleared on any exit path
     }
     async isWebsocketConnected() {
         if (typeof this._ws !== 'undefined' && this._eventListener !== null) {
@@ -31,7 +35,18 @@ class WebsocketClient extends BaseClass {
         return this.lastWebsocketMessage;
     }
     async listen() {
+        // Clear any leftover ping interval from a previous connection
+        if (this._pingpong) {
+            this.homey.clearInterval(this._pingpong);
+            this._pingpong = null;
+        }
+
         try {
+            // Close any existing socket before opening a new one to avoid orphan connections
+            if (this._ws) {
+                try { this._ws.terminate(); } catch (e) {}
+            }
+
             const cookies = await this.homey.app.api.unifi._cookieJar.getCookieString(this._baseurl.href);
 
             let eventsUrl = `wss://${this._baseurl.host}/wss/s/${this.opts.site}/events`;
@@ -47,15 +62,23 @@ class WebsocketClient extends BaseClass {
                 }
             });
 
-            const pingpong = setInterval(() => {
+            this._pingpong = this.homey.setInterval(() => {
                 try {
+                    // If no pong received within 3 ping intervals, the connection is half-dead — force reconnect
+                    if (this._lastPong && Date.now() - this._lastPong > this._pingPongInterval * 3) {
+                        this.homey.log('[websocket] pong timeout — forcing reconnect');
+                        this._lastPong = null; // prevent double terminate on next tick before close fires
+                        this._ws.terminate();
+                        return;
+                    }
                     this._ws.send('ping');
                 } catch (error) {
-                    this.homey.error(`${JSON.stringify(error)}`);
+                    this.homey.error(`${error.message || error}`);
                 }
             }, this._pingPongInterval);
 
             this._ws.on('open', () => {
+                this._lastPong = Date.now(); // reset so timeout doesn't fire immediately on reconnect
                 this.homey.app.debug(`WebSocket: open`);
             });
 
@@ -65,6 +88,7 @@ class WebsocketClient extends BaseClass {
                 //
                 const message = isBinary ? data : data.toString();
                 if (message === 'pong') {
+                    this._lastPong = Date.now(); // track for pong timeout detection
                     this.homey.app.debug(`Websocket: pong`);
                     return;
                 }
@@ -74,45 +98,77 @@ class WebsocketClient extends BaseClass {
                     if ('meta' in parsed && Array.isArray(parsed.data)) {
                         for (const entry of parsed.data) {
                             //                       this.homey.app.debug(`${JSON.stringify(entry)}`);
-                            this.homey.app.parseWebsocketMessage(entry);
+                            // Pass meta so parseWebsocketMessage can identify device:sync events
+                            this.homey.app.parseWebsocketMessage(entry, parsed.meta);
                         }
                     }
                 } catch (error) {
-                    this.homey.error(`[websocket] [message]: ${JSON.stringify(error)}`);
+                    this.homey.error(`[websocket] [message]: ${error.message || error}`);
                 }
             });
 
             this._ws.on('close', () => {
-                this.homey.app.debug(`WebSocket: close`);
-                clearInterval(pingpong);
-                this._reconnect();
+                this.homey.clearInterval(this._pingpong);
+                this._pingpong = null;
+                if (this._closed) {
+                    this.homey.log('[websocket] connection closed');
+                } else {
+                    this.homey.log('[websocket] connection closed, reconnecting...');
+                    this._reconnect();
+                }
             });
 
             this._ws.on('error', error => {
-                this.homey.app.debug(`${JSON.stringify(error)}`);
-                clearInterval(pingpong);
+                this.homey.log(`[websocket] error: ${error.message || error}`);
+                this.homey.clearInterval(this._pingpong);
+                this._pingpong = null;
                 this._reconnect();
             });
 
             return true;
         } catch(ex) {
-            this.homey.error('Exeption in listing()');
+            // Clear interval on any setup failure so it doesn't leak
+            if (this._pingpong) {
+                this.homey.clearInterval(this._pingpong);
+                this._pingpong = null;
+            }
+            this.homey.error('Exception in listen()');
             this.homey.error(JSON.stringify(ex));
             return false;
         }
     }
 
     _reconnect() {
-        if (this._isReconnecting === false && this.homey.app.api.unifi._isClosed === false) {
+        if (this._isReconnecting === false && this._closed === false) {
             this._isReconnecting = true;
-            setTimeout(async () => {
-                this._isReconnecting = false;
+            this.homey.setTimeout(async () => {
+                // Re-check _closed after the delay — client may have been replaced while waiting
+                if (this._closed) {
+                    this._isReconnecting = false;
+                    return;
+                }
                 try {
                     await this.listen();
+                    // Keep _isReconnecting true during listen() so a close event on the old socket
+                    // (triggered by terminate() inside listen()) can't schedule a second reconnect
+                    this._isReconnecting = false;
                 } catch (error) {
-                    this.error('_reconnect() encountered an error: ' + error);
+                    this.homey.error('_reconnect() encountered an error: ' + error);
+                    this._isReconnecting = false; // reset before retry so the guard passes
+                    this._reconnect();
                 }
             }, this._autoReconnectInterval);
+        }
+    }
+
+    destroy() {
+        this._closed = true;
+        if (this._pingpong) {
+            this.homey.clearInterval(this._pingpong);
+            this._pingpong = null;
+        }
+        if (this._ws) {
+            try { this._ws.terminate(); } catch (e) {}
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds real-time PoE power (W), voltage (V), current (A), and cumulative energy (kWh) capabilities to wired cable-clients, access-points, and PoE-powered network switches
- Introduces `library/poe-power-mixin.js` — a shared mixin that normalises UniFi's two uplink field layouts (`sw_mac`/`sw_port` for clients vs `uplink.uplink_mac`/`uplink.uplink_remote_port` for infrastructure) and handles capability management, kWh accumulation, and persistence
- Extends WebSocket `device:sync` handling in `app.js` to push live port-level PoE data to whichever device is connected on that port
- Fixes WebSocket reconnect so the real-time data stream survives overnight (without this fix, the WS died silently and PoE fell back to 5-minute polling)

## How it works

1. On boot, each device calls `updatePoeUplink()` to record which switch MAC + port it is connected to, then `_fetchPoeData()` seeds the initial reading via the REST API
2. When the UniFi controller pushes a `device:sync` WebSocket event, `app.js` matches connected devices by `_swMac`/`_swPort` and calls `onPoeUpdate(port)` directly — no polling required (~30 s cadence driven by the controller)
3. kWh is accumulated in-memory and persisted to device store on every update; the accumulation skips the unknown gap on restart to avoid inflated totals

## Capabilities added (dynamically, only when PoE data is present)

| Capability | Unit |
|---|---|
| `measure_power` | W |
| `measure_voltage` | V |
| `measure_current` | A |
| `meter_power` | kWh |

## WebSocket fix (`library/websocket.js`, `library/apiclient.js`)

`_isReconnecting` was never initialized in the constructor. The reconnect guard uses strict equality (`=== false`), so `undefined === false` is `false` — meaning `_reconnect()` silently no-opped on every close/error event. The WebSocket died permanently with no log output.

Additional fixes:
- **Pong timeout detection** — if no pong arrives within 3× ping interval (~9 s), force-terminate to recover half-dead connections
- **Close old socket in `listen()`** — terminate existing `_ws` before creating a new one to avoid orphan connections on reconnect
- **Close old socket in `setWebSocketObject()`** — the hourly `refreshAuthTokens` re-login was leaking orphan connections
- **`homey.log` for close/error** — was `debug()`, invisible in production; lifecycle events now always appear in logs
- **Fix `this.error()` → `this.homey.error()`** in `_reconnect()` catch block (pre-existing silent bug)

## Test plan

- [ ] Wired cable-client connected to a PoE port shows power/voltage/current/kWh in Homey Energy tab
- [ ] Non-PoE wired client does not show power capabilities
- [ ] Access-point powered via PoE shows power capabilities
- [ ] Network switch powered via PoE shows power capabilities
- [ ] kWh value persists across Homey reboot
- [ ] Leave running overnight — Insights chart shows continuous high-frequency PoE updates, not 5-minute gaps
- [ ] `homey app validate --level publish` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)